### PR TITLE
[Godot4] Update API to beta 16 breaks compat change

### DIFF
--- a/addons/AS2P/NodeSelectorProperty.gd
+++ b/addons/AS2P/NodeSelectorProperty.gd
@@ -56,7 +56,7 @@ func convert_sprites():
 	var count := 0
 	var updated_count := 0
 
-	var sprite_frames := animated_sprite.frames
+	var sprite_frames := animated_sprite.sprite_frames
 
 	if not sprite_frames:
 		print("[AS2P] Selected AnimatedSprite2D has no frames!")


### PR DESCRIPTION
… from https://github.com/godotengine/godot/pull/71907

Explanation: the commit "Make AnimatedSprite's playback API consistent with AnimationPlayer #71907" renamed AnimatedSprite2D.frames to sprite_frames