### PR TITLE
feat: support both AnimatedSprite2D and AnimatedSprite3D

### DIFF
--- a/addons/AS2P/InspectorConvertor.gd
+++ b/addons/AS2P/InspectorConvertor.gd
@@ -20,11 +20,11 @@ func _can_handle(object):
 
 ## Create UI here
 func _parse_end(object: Object):
-	var header = CustomEditorInspectorCategory.new("Import AnimatedSprite2D")
+	var header = CustomEditorInspectorCategory.new("Import AnimatedSprite2D/3D")
 
 	# AnimatedSprite2D Node selector
 	node_selector = NodeSelectorProperty.new(anim_player)
-	node_selector.label = "AnimatedSprite2D Node"
+	node_selector.label = "AnimatedSprite2D/3D Node"
 
 	node_selector.animation_updated.connect(
 		_on_animation_updated,
@@ -41,7 +41,7 @@ func _parse_end(object: Object):
 	var buttonstyle = StyleBoxFlat.new()
 	buttonstyle.bg_color = Color8(32, 37, 49)
 	button.set("custom_styles/normal", buttonstyle)
-	
+
 	var container = VBoxContainer.new()
 	container.add_spacer(true)
 
@@ -60,13 +60,13 @@ func _on_animation_updated():
 class CustomEditorInspectorCategory extends Control:
 	var title: String = ""
 	var icon: Texture2D = null
-	
+
 	func _init(p_title: String, p_icon: Texture2D = null):
 		title = p_title
 		icon = p_icon
-		
+
 		tooltip_text = "AnimatedSprite to AnimationPlayer Plugin"
-		
+
 	func _get_minimum_size() -> Vector2:
 		var font := get_theme_font(&"bold", &"EditorFonts");
 		var font_size := get_theme_font_size(&"bold_size", &"EditorFonts");
@@ -75,32 +75,31 @@ class CustomEditorInspectorCategory extends Control:
 		ms.y = font.get_height(font_size);
 		if icon:
 			ms.y = max(icon.get_height(), ms.y);
-		
+
 		ms.y += get_theme_constant(&"v_separation", &"Tree");
 
 		return ms;
-	
+
 	func _draw() -> void:
 		var sb := get_theme_stylebox(&"bg", &"EditorInspectorCategory")
 		draw_style_box(sb, Rect2(Vector2.ZERO, size))
-		
+
 		var font := get_theme_font(&"bold", &"EditorFonts")
 		var font_size := get_theme_font_size(&"bold_size", &"EditorFonts")
-		
+
 		var hs := get_theme_constant(&"h_separation", &"Tree")
-		
+
 		var w: int = font.get_string_size(title, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x;
 		if icon:
 			w += hs + icon.get_width();
-		
+
 
 		var ofs := (get_size().x - w) / 2;
 
 		if icon:
 			draw_texture(icon, Vector2(ofs, (get_size().y - icon.get_height()) / 2).floor())
 			ofs += hs + icon.get_width()
-		
+
 		var color := get_theme_color(&"font_color", &"Tree")
 		draw_string(font, Vector2(ofs, font.get_ascent(font_size) + (get_size().y - font.get_height(font_size)) / 2).floor(), title, HORIZONTAL_ALIGNMENT_LEFT, get_size().x, font_size, color);
-		
-		
+

--- a/addons/AS2P/NodeSelectorProperty.gd
+++ b/addons/AS2P/NodeSelectorProperty.gd
@@ -9,7 +9,7 @@ var drop_down := OptionButton.new()
 
 signal animation_updated()
 
-func get_animatedsprite() -> AnimatedSprite2D:
+func get_animatedsprite():
 	var root = get_tree().edited_scene_root
 	return _get_animated_sprites(root)[drop_down.selected]
 
@@ -19,7 +19,7 @@ func _get_animated_sprites(root: Node) -> Array:
 	for child in root.get_children():
 		asNodes += _get_animated_sprites(child)
 
-	if root is AnimatedSprite2D:
+	if root is AnimatedSprite2D or root is AnimatedSprite3D:
 		asNodes.append(root)
 
 	return asNodes
@@ -51,12 +51,12 @@ func get_items():
 		drop_down.add_item(anim_player.get_path_to(anim_sprite), i)
 
 func convert_sprites():
-	var animated_sprite: AnimatedSprite2D = get_node(get_animatedsprite().get_path())
+	var animated_sprite = get_node(get_animatedsprite().get_path())
 
 	var count := 0
 	var updated_count := 0
 
-	var sprite_frames := animated_sprite.sprite_frames
+	var sprite_frames = animated_sprite.sprite_frames
 
 	if not sprite_frames:
 		print("[AS2P] Selected AnimatedSprite2D has no frames!")
@@ -72,19 +72,19 @@ animation named empty string '', it will be ignored" % animated_sprite.name)
 				anim,
 				sprite_frames
 			)
-		
+
 		count += 1
-		
+
 		if updated:
 			updated_count += 1
-		
+
 	if count - updated_count > 0:
 		print("[AS2P] Added %d animations!" % [count - updated_count])
 	if updated_count > 0:
 		print("[AS2P] Updated %d animations!" % updated_count)
 
 	emit_signal("animation_updated")
-	
+
 func add_animation(anim_sprite: NodePath, anim: String, sprite_frames: SpriteFrames):
 	var frame_count = sprite_frames.get_frame_count(anim)
 	var fps = sprite_frames.get_animation_speed(anim)
@@ -109,13 +109,13 @@ func add_animation(anim_sprite: NodePath, anim: String, sprite_frames: SpriteFra
 	# Animation Player library, so sanitize the name
 	var sanitized_anim_name = anim.replace(":", "_")
 	sanitized_anim_name = sanitized_anim_name.replace("[", "_")
-	
+
 	var updated := false
 	var animation: Animation = null
 
 	if global_animation_library.has_animation(sanitized_anim_name):
 		animation = global_animation_library.get_animation(sanitized_anim_name)
-		
+
 		updated = true
 	else:
 		animation = Animation.new()
@@ -131,17 +131,17 @@ func add_animation(anim_sprite: NodePath, anim: String, sprite_frames: SpriteFra
 	# Remove existing tracks
 	var animation_name_path := "%s:animation" % anim_sprite
 	var frame_path := "%s:frame" % anim_sprite
-	
+
 	var anim_track: int = animation.find_track(animation_name_path, Animation.TYPE_VALUE)
 	var frame_track: int = animation.find_track(frame_path, Animation.TYPE_VALUE)
-	
+
 	if frame_track >= 0:
 		animation.remove_track(anim_track)
 	if anim_track >= 0:
 		animation.remove_track(frame_track)
-		
+
 	# Add and create tracks
-	
+
 	frame_track = animation.add_track(Animation.TYPE_VALUE, 0)
 	anim_track = animation.add_track(Animation.TYPE_VALUE, 1)
 
@@ -162,7 +162,7 @@ func add_animation(anim_sprite: NodePath, anim: String, sprite_frames: SpriteFra
 	for i in range(frame_count):
 		# Insert key at next key time
 		animation.track_insert_key(frame_track, next_key_time, i)
-		
+
 		# Prepare key time for next sprite by adding duration of current sprite
 		# including Frame Duration multiplier
 		var frame_duration_multiplier = sprite_frames.get_frame_duration(anim, i)


### PR DESCRIPTION
Hi poohcom1, thank you for this brilliant addon.

Meanwhile I'm working on a HD2D-ish project, finding this addon can only work with `AnimatedSprite2D`. I suppose it could support 3D as well so I modified some lines to have it recognize both `AnimatedSprite2D` and `AnimatedSprite3D` nodes. Turned out it works for my project. So here's my PR.

Please forgive my formatter eliminating all the tabs on the blank lines. Please let me know how you think.

Thanks
mogita