### PR TITLE
Add menu button for selecting which animations to import on each import

### DIFF
--- a/addons/AS2P/AnimationSelectorProperty.gd
+++ b/addons/AS2P/AnimationSelectorProperty.gd
@@ -1,0 +1,142 @@
+@tool
+extends EditorProperty
+## @desc Inspector property for selecting the animations to import.
+##
+
+const ID_SELECT_ALL := 0
+const ID_SELECT_NONE := 1
+const ID_SEPARATOR := 2
+const RESERVED_ID_COUNT := 3
+
+var anim_player: AnimationPlayer
+var menu_button := MenuButton.new()
+
+var animations: Array[AnimationState] = []
+var animations_selected: Array[String]:
+	get:
+		var result: Array[String] = []
+		for animation in animations:
+			if animation.selected:
+				result.append(animation.name)
+		return result
+
+signal animations_updated()
+
+func _init(_anim_player):
+	anim_player = _anim_player
+
+	menu_button.clip_text = true
+	# Add the control as a direct child of EditorProperty node.
+	add_child(menu_button)
+	# Make sure the control is able to retain the focus.
+	add_focusable(menu_button)
+
+	_configure_popup()
+	_update_button_label()
+
+func _ready():
+	get_items(null)
+
+func _configure_popup():
+	var popup = menu_button.get_popup()
+
+	popup.clear()
+	popup.hide_on_checkable_item_selection = false
+	popup.hide_on_item_selection = false
+	popup.id_pressed.connect(_on_popup_id_pressed)
+
+func _update_button_label():
+	var selected_count = 0
+	for i in range(len(animations)):
+		var animation = animations[i]
+		if animation.selected:
+			selected_count += 1
+
+	menu_button.text = "%d of %d Selected" % [selected_count, len(animations)]
+
+func get_items(animated_sprite: AnimatedSprite2D):
+	if animated_sprite == null:
+		menu_button.get_popup().clear()
+		return
+
+	_populate_animations(animated_sprite)
+	_populate_menu()
+	_update_button_label()
+
+func _populate_animations(animated_sprite: AnimatedSprite2D):
+	animations.clear()
+
+	var animation_names = animated_sprite.sprite_frames.get_animation_names()
+
+	print("[AS2P] %s" % [animation_names])
+
+	for i in range(len(animation_names)):
+		var name = animation_names[i]
+
+		var animation := AnimationState.new(
+			i + RESERVED_ID_COUNT,
+			name
+			)
+
+		animations.append(animation)
+
+func _populate_menu():
+	var popup = menu_button.get_popup()
+	popup.clear()
+
+	popup.add_item("Select All", ID_SELECT_ALL)
+	popup.add_item("Select None", ID_SELECT_NONE)
+	popup.add_separator("", ID_SEPARATOR)
+
+	for i in range(len(animations)):
+		var animation = animations[i]
+
+		popup.add_check_item(animation.name, animation.id)
+		popup.set_item_checked(animation.id, animation.selected)
+
+func _on_popup_id_pressed(id: int):
+	var popup = menu_button.get_popup()
+
+	if id == ID_SELECT_ALL:
+		for animation in animations:
+			animation.selected = true
+
+			popup.set_item_checked(animation.id, animation.selected)
+
+		_update_button_label()
+	elif id == ID_SELECT_NONE:
+		for animation in animations:
+			animation.selected = false
+
+			popup.set_item_checked(animation.id, animation.selected)
+
+		_update_button_label()
+	elif id >= RESERVED_ID_COUNT:
+		# Animation selection
+		var animation = animations[_menu_id_to_animation_index(id)]
+
+		animation.selected = !animation.selected
+
+		popup.set_item_checked(id, animation.selected)
+
+		_update_button_label()
+
+func _menu_id_to_animation_index(id: int):
+	for i in range(len(animations)):
+		if animations[i].id == id:
+			return i
+
+	return -1
+
+func get_tooltip_text():
+	return "Animations to import."
+
+class AnimationState:
+	var id: int
+	var name: String
+	var selected: bool
+
+	func _init(id: int, name: String, selected: bool = true) -> void:
+		self.id = id
+		self.name = name
+		self.selected = selected

--- a/addons/AS2P/InspectorConvertor.gd
+++ b/addons/AS2P/InspectorConvertor.gd
@@ -2,8 +2,10 @@
 extends EditorInspectorPlugin
 
 const NodeSelectorProperty = preload("./NodeSelectorProperty.gd")
+const AnimationSelectorProperty = preload("./AnimationSelectorProperty.gd")
 
 var node_selector: NodeSelectorProperty
+var animation_selector: AnimationSelectorProperty
 
 # Properties
 var anim_player: AnimationPlayer
@@ -30,13 +32,19 @@ func _parse_end(object: Object):
 		_on_animation_updated,
 		CONNECT_DEFERRED
 		)
+	node_selector.animated_sprite_updated.connect(
+		_on_animated_sprite_updated,
+		CONNECT_DEFERRED
+		)
 
+	animation_selector = AnimationSelectorProperty.new(anim_player)
+	animation_selector.label = "Animations"
 
 	# Import button
 	var button := Button.new()
 	button.text = "Import"
 	button.get_minimum_size().y = 26
-	button.button_down.connect(node_selector.convert_sprites)
+	button.button_down.connect(_on_import_button_down)
 
 	var buttonstyle = StyleBoxFlat.new()
 	buttonstyle.bg_color = Color8(32, 37, 49)
@@ -47,6 +55,7 @@ func _parse_end(object: Object):
 
 	container.add_child(header)
 	container.add_child(node_selector)
+	container.add_child(animation_selector)
 	container.add_spacer(false)
 	container.add_child(button)
 
@@ -55,6 +64,12 @@ func _parse_end(object: Object):
 
 func _on_animation_updated():
 	emit_signal("animation_updated", anim_player)
+
+func _on_animated_sprite_updated(animated_sprite: AnimatedSprite2D):
+	animation_selector.get_items(animated_sprite)
+
+func _on_import_button_down():
+	node_selector.convert_sprites(animation_selector.animations_selected)
 
 # Child class
 class CustomEditorInspectorCategory extends Control:
@@ -102,4 +117,3 @@ class CustomEditorInspectorCategory extends Control:
 
 		var color := get_theme_color(&"font_color", &"Tree")
 		draw_string(font, Vector2(ofs, font.get_ascent(font_size) + (get_size().y - font.get_height(font_size)) / 2).floor(), title, HORIZONTAL_ALIGNMENT_LEFT, get_size().x, font_size, color);
-

--- a/addons/AS2P/NodeSelectorProperty.gd
+++ b/addons/AS2P/NodeSelectorProperty.gd
@@ -8,6 +8,8 @@ var anim_player: AnimationPlayer
 var drop_down := OptionButton.new()
 
 signal animation_updated()
+signal animated_sprite_updated(animated_sprite: AnimatedSprite2D)
+signal items_updated()
 
 func get_animatedsprite():
 	var root = get_tree().edited_scene_root
@@ -35,9 +37,10 @@ func _init(_anim_player):
 
 	drop_down.clear()
 
+	drop_down.item_selected.connect(_on_drop_down_item_selected)
+
 func _ready():
 	get_items()
-
 
 func get_items():
 	drop_down.clear()
@@ -50,7 +53,15 @@ func get_items():
 
 		drop_down.add_item(anim_player.get_path_to(anim_sprite), i)
 
-func convert_sprites():
+	emit_signal("items_updated")
+
+	if not anim_sprites.is_empty():
+		emit_signal("animated_sprite_updated", anim_sprites[0])
+
+func _on_drop_down_item_selected(index: int):
+	emit_signal("animated_sprite_updated", get_animatedsprite())
+
+func convert_sprites(animations_to_import: Array[String]):
 	var animated_sprite = get_node(get_animatedsprite().get_path())
 
 	var count := 0
@@ -62,6 +73,9 @@ func convert_sprites():
 		print("[AS2P] Selected AnimatedSprite2D has no frames!")
 
 	for anim in sprite_frames.get_animation_names():
+		if not animations_to_import.has(anim):
+			continue
+
 		if anim.is_empty():
 			printerr("[AS2P] SpriteFrames on AnimatedSprite2D '%s' has an \
 animation named empty string '', it will be ignored" % animated_sprite.name)


### PR DESCRIPTION
This PR adds a new button in the UI that allows the user to select which animations to import, using a popup menu interface.

I found that it could be useful to only import a few animations at a time when iterating a sprite in an external program, since re-importing animations has a tendency to duplicate tracks currently.