### PR TITLE
Fix #26: in animated sprite dropdown, show parent before children

### DIFF
--- a/addons/AS2P/NodeSelectorProperty.gd
+++ b/addons/AS2P/NodeSelectorProperty.gd
@@ -16,11 +16,11 @@ func get_animatedsprite():
 func _get_animated_sprites(root: Node) -> Array:
 	var asNodes := []
 
-	for child in root.get_children():
-		asNodes += _get_animated_sprites(child)
-
 	if root is AnimatedSprite2D or root is AnimatedSprite3D:
 		asNodes.append(root)
+		
+	for child in root.get_children():
+		asNodes += _get_animated_sprites(child)
 
 	return asNodes
 

--- a/test/TestScene.tscn
+++ b/test/TestScene.tscn
@@ -161,7 +161,7 @@ step = 0.0833333
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("AnimatedSprite2D:frame")
+tracks/0/path = NodePath("AnimatedSprite2D_Parent:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -173,7 +173,7 @@ tracks/0/keys = {
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("AnimatedSprite2D:animation")
+tracks/1/path = NodePath("AnimatedSprite2D_Parent:animation")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
@@ -190,7 +190,7 @@ step = 0.2
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("AnimatedSprite2D:frame")
+tracks/0/path = NodePath("AnimatedSprite2D_Parent:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -202,7 +202,7 @@ tracks/0/keys = {
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("AnimatedSprite2D:animation")
+tracks/1/path = NodePath("AnimatedSprite2D_Parent:animation")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
@@ -218,7 +218,7 @@ loop_mode = 1
 tracks/0/type = "value"
 tracks/0/imported = false
 tracks/0/enabled = true
-tracks/0/path = NodePath("AnimatedSprite2D:frame")
+tracks/0/path = NodePath("AnimatedSprite2D_Parent:frame")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
@@ -230,7 +230,7 @@ tracks/0/keys = {
 tracks/1/type = "value"
 tracks/1/imported = false
 tracks/1/enabled = true
-tracks/1/path = NodePath("AnimatedSprite2D:animation")
+tracks/1/path = NodePath("AnimatedSprite2D_Parent:animation")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
@@ -262,9 +262,13 @@ _data = {
 [node name="TestScene" type="Node2D"]
 texture_filter = 1
 
-[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+[node name="AnimatedSprite2D_Parent" type="AnimatedSprite2D" parent="."]
 sprite_frames = SubResource("SpriteFrames_k73iy")
 animation = &"idle"
+
+[node name="AnimatedSprite2D_Child" type="AnimatedSprite2D" parent="AnimatedSprite2D_Parent"]
+sprite_frames = SubResource("SpriteFrames_k73iy")
+animation = &"attack"
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {


### PR DESCRIPTION
by appending root before recursively adding children

Improve Test Scene to add a child animated sprite to demonstrate the fix